### PR TITLE
Correct syntax errors in Javadoc comments

### DIFF
--- a/slib-examples/src/main/java/slib/examples/graph/traversal/GO_BFS.java
+++ b/slib-examples/src/main/java/slib/examples/graph/traversal/GO_BFS.java
@@ -55,7 +55,7 @@ import slib.utils.ex.SLIB_Exception;
  * Basic example which shows how to perform a Breadth-First Search on the Gene
  * Ontology.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GO_BFS {
 

--- a/slib-examples/src/main/java/slib/examples/sml/general/GraphExample.java
+++ b/slib-examples/src/main/java/slib/examples/sml/general/GraphExample.java
@@ -52,7 +52,7 @@ import slib.utils.ex.SLIB_Exception;
  * 
  * More information at http://www.semantic-measures-library.org/
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphExample {
     

--- a/slib-examples/src/main/java/slib/examples/sml/general/SMComputation.java
+++ b/slib-examples/src/main/java/slib/examples/sml/general/SMComputation.java
@@ -60,7 +60,7 @@ import slib.utils.ex.SLIB_Exception;
  * 
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root element, change value="INFO" to value="DEBUG"
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputation {
     

--- a/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_extrinsic_IC.java
+++ b/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_extrinsic_IC.java
@@ -64,7 +64,7 @@ import slib.utils.ex.SLIB_Exception;
  * More information at http://www.semantic-measures-library.org/
  *
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationGO_extrinsic_IC {
 

--- a/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_groupwise.java
+++ b/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_groupwise.java
@@ -69,7 +69,7 @@ import slib.utils.impl.Timer;
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root
  * element, change value="INFO" to value="DEBUG"
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationGO_groupwise {
 

--- a/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_groupwise_million.java
+++ b/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_groupwise_million.java
@@ -72,7 +72,7 @@ import slib.utils.impl.Timer;
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root
  * element, change value="INFO" to value="DEBUG"
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationGO_groupwise_million {
 

--- a/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_pairwise.java
+++ b/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_pairwise.java
@@ -63,7 +63,7 @@ import slib.utils.ex.SLIB_Exception;
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root
  * element, change value="INFO" to value="DEBUG"
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationGO_pairwise {
 

--- a/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_pairwise_edge_based.java
+++ b/slib-examples/src/main/java/slib/examples/sml/go/SMComputationGO_pairwise_edge_based.java
@@ -60,7 +60,7 @@ import slib.utils.ex.SLIB_Exception;
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root
  * element, change value="INFO" to value="DEBUG"
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationGO_pairwise_edge_based {
 

--- a/slib-examples/src/main/java/slib/examples/sml/mesh/MeSHExample_XML.java
+++ b/slib-examples/src/main/java/slib/examples/sml/mesh/MeSHExample_XML.java
@@ -56,7 +56,7 @@ import slib.utils.impl.Timer;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeSHExample_XML {
 

--- a/slib-examples/src/main/java/slib/examples/sml/mesh/MeSHExample_XML_2013.java
+++ b/slib-examples/src/main/java/slib/examples/sml/mesh/MeSHExample_XML_2013.java
@@ -62,13 +62,13 @@ import slib.utils.impl.Timer;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeSHExample_XML_2013 {
 
     /**
      * Remove the cycles from the MeSH Graph see
-     * http://semantic-measures-library.org/sml/index.php?q=doc&page=mesh 
+     * {@literal http://semantic-measures-library.org/sml/index.php?q=doc&page=mesh }
      * for more information
      *
      * @param meshGraph the graph associated to the MeSH

--- a/slib-examples/src/main/java/slib/examples/sml/owl/SMComputationOWL.java
+++ b/slib-examples/src/main/java/slib/examples/sml/owl/SMComputationOWL.java
@@ -60,7 +60,7 @@ import slib.utils.impl.Timer;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationOWL {
 

--- a/slib-examples/src/main/java/slib/examples/sml/snomedct/SMComputationSnomedCT.java
+++ b/slib-examples/src/main/java/slib/examples/sml/snomedct/SMComputationSnomedCT.java
@@ -64,7 +64,7 @@ import slib.utils.impl.Timer;
  * Note that you can set the LOG level in specified in log4j.xml, e.g. in root
  * element, change value="INFO" to value="DEBUG"
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationSnomedCT {
 

--- a/slib-examples/src/main/java/slib/examples/sml/wordnet/WordnetExample.java
+++ b/slib-examples/src/main/java/slib/examples/sml/wordnet/WordnetExample.java
@@ -62,7 +62,7 @@ import slib.utils.ex.SLIB_Exception;
  *
  * Documentation: http://www.semantic-measures-library.org
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class WordnetExample {
 

--- a/slib-examples/src/main/java/slib/examples/sml/yago/SMComputationYago.java
+++ b/slib-examples/src/main/java/slib/examples/sml/yago/SMComputationYago.java
@@ -59,7 +59,7 @@ import slib.utils.impl.Timer;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMComputationYago {
     

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/accessor/GraphAccessor.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/accessor/GraphAccessor.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphAccessor {
 
@@ -58,11 +58,11 @@ public class GraphAccessor {
      * Return a set of URI corresponding to the classes of the graph. A vertex v
      * of the graph is considered as a class if the graph contains a statement
      * of the form :
-     * <ul>
-     * <li> v RFDS.SUBCLASSOF ? </li>
-     * <li> ? RDFS.SUBCLASSOF v </li>
-     * <li> ? RDF.TYPE v </li>
-     * </ul>
+       <ul>
+       <li> v RFDS.SUBCLASSOF ? </li>
+       <li> ? RDFS.SUBCLASSOF v </li>
+       <li> ? RDF.TYPE v </li>
+       </ul>
      *
      * @param graph the graph
      * @return a set of URI corresponding to the classes of the graph
@@ -91,13 +91,13 @@ public class GraphAccessor {
      * Return a set of URI corresponding to the instances of the graph, note
      * that instance. A vertex v of the graph is considered as an instance if the
      * graph do not contains a statement of the form :
-     * <ul>
-     * <li> v RFD.TYPE ? with ? not equals to
-     * RDFS.RESOURCE/CLASS/LITERAL/DATATYPE/PROPERTY/XMLLITERAL or OWL.CLASS
-     * </li>
-     * Those restrictions do not cover all cases e.g. RDF instance of
-     * RDFS.CONTAINER will be considered as instance...
-     * </ul>
+       <ul>
+       <li> v RFD.TYPE ? with ? not equals to
+       RDFS.RESOURCE/CLASS/LITERAL/DATATYPE/PROPERTY/XMLLITERAL or OWL.CLASS
+       </li>
+       </ul>
+       Those restrictions do not cover all cases e.g. RDF instance of
+       RDFS.CONTAINER will be considered as instance...
      *
      * @param graph the graph
      * @return a set of URI corresponding to the classes of the graph

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/metric/DepthAnalyserAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/metric/DepthAnalyserAG.java
@@ -55,7 +55,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Class used to analyze depth of vertices composing an acyclic graph
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class DepthAnalyserAG {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/reduction/dag/GraphReduction_DAG_Ranwez_2011.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/reduction/dag/GraphReduction_DAG_Ranwez_2011.java
@@ -59,14 +59,14 @@ import slib.utils.impl.SetUtils;
 
 /**
  * Algorithm used to extract a subgraph from a DAG (Directed Acyclic Graph)
- * <br/> Implementation of Ranwez et al. 2011 algorithm. <br/>
- * original paper: <br/>
+ * <br> Implementation of Ranwez et al. 2011 algorithm. <br>
+ * original paper: <br>
  *
- * ﻿Ranwez V, Ranwez S, Janaqi S: Sub-Ontology Extraction Using Hyponym and
+ * Ranwez V, Ranwez S, Janaqi S: Sub-Ontology Extraction Using Hyponym and
  * Hypernym Closure on is-a Directed Acyclic Graphs. IEEE Transactions on
  * Knowledge and Data Engineering 2011, 99:1-14.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphReduction_DAG_Ranwez_2011 {
 
@@ -87,7 +87,7 @@ public class GraphReduction_DAG_Ranwez_2011 {
      * Method used to perform the subGraph extraction of an acyclic graph based
      * on top-down and bottom-up transitive closures.
      *
-     * The reduction is performed considering: <br/>
+     * The reduction is performed considering: <br>
      * <ul>
      * <li>
      * A set of URIs corresponding to the vertices on which must be based the

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/reduction/dag/GraphReduction_Transitive.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/reduction/dag/GraphReduction_Transitive.java
@@ -56,7 +56,7 @@ import slib.utils.impl.SetUtils;
  * Class used to perform a transitive reduction of a DAG see
  * http://en.wikipedia.org/wiki/Transitive_reduction
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class GraphReduction_Transitive {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/AncestorEngine.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/AncestorEngine.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Class used to provide an easy way to retrieve the ancestors of a concept
  * (super classes of a class).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class AncestorEngine extends RVF_TAX {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/DescendantEngine.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/DescendantEngine.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class DescendantEngine extends RVF_TAX {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF.java
@@ -53,7 +53,7 @@ import slib.graph.model.graph.utils.WalkConstraint;
  * constraints e.g. type of relationships (i.e. set of predicate URI) particular
  * vertex restriction applied to the walk.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class RVF {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF_DAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF_DAG.java
@@ -53,7 +53,7 @@ import slib.utils.impl.SetUtils;
  * particular vertex of an acyclic graph considering particular relationships
  * i.e. EdgeTypes
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class RVF_DAG extends RVF {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF_TAX.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/RVF_TAX.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Object of this class can be used to retrieve the vertices reachable from a
  * particular vertex of an acyclic graph considering taxonomic relationships.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class RVF_TAX extends RVF_DAG {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/instances/InstancesAccessor.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/instances/InstancesAccessor.java
@@ -40,7 +40,7 @@ import org.openrdf.model.URI;
  *
  * Interface defining a access to the instances of the classes
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface InstancesAccessor {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/instances/impl/InstanceAccessor_RDF_TYPE.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/rvf/instances/impl/InstanceAccessor_RDF_TYPE.java
@@ -44,7 +44,7 @@ import slib.graph.model.graph.utils.Direction;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class InstanceAccessor_RDF_TYPE implements InstancesAccessor {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/shortest_path/Dijkstra.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/shortest_path/Dijkstra.java
@@ -52,7 +52,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * href="http://en.wikipedia.org/wiki/Dijkstra's_algorithm">more about</a> TODO
  * optimize i.e Fibonacci heap implementation
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Dijkstra {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/GraphTraversal.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/GraphTraversal.java
@@ -38,7 +38,7 @@ import org.openrdf.model.URI;
 /**
  * GraphTraversal interface
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/classical/BFS.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/classical/BFS.java
@@ -55,7 +55,7 @@ import slib.utils.impl.SetUtils;
  * <a href="http://en.wikipedia.org/wiki/Breadth-first_search">more about
  * BFS</a>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class BFS implements GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/classical/DFS.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/traversal/classical/DFS.java
@@ -56,7 +56,7 @@ import slib.utils.impl.SetUtils;
  * creation. The iteration is then made on the stored topological sort. The
  * topological sort can also be retrieve.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class DFS implements GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/Color.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/Color.java
@@ -38,7 +38,7 @@ package slib.graph.algo.extraction.utils;
  * Enumeration used to represent colors.
  * Used for graph algorithms.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum Color {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GAction.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GAction.java
@@ -39,7 +39,7 @@ import slib.utils.impl.ParametrableImpl;
 /**
  * Class used to represent an action which is applicable to a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GAction extends ParametrableImpl implements CheckableValidity {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GActionType.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GActionType.java
@@ -37,7 +37,7 @@ package slib.graph.algo.extraction.utils;
  * Enumeration used to represent the various types of actions which can be
  * applied to a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum GActionType {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GActionValidator.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GActionValidator.java
@@ -36,7 +36,7 @@ package slib.graph.algo.extraction.utils;
 /**
  * Class used to validate if the configuration associated to a {@link GAction} is valid.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GActionValidator {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GraphActionExecutor.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/GraphActionExecutor.java
@@ -68,7 +68,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Class managing the execution of {@link GAction} over a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphActionExecutor {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/RooterDAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/utils/RooterDAG.java
@@ -49,14 +49,14 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Object used to root a graph taking into consideration edge types defining
  * roots.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class RooterDAG {
 
     /**
      * Add a unique root to a DAG (underlying DAG) composed of multiple roots.
-     * <br/> The processed graph must be/contains a DAG according to a specified
+     * <br> The processed graph must be/contains a DAG according to a specified
      * set of edge type here called EtypeDAG. In other words the reduction of
      * the given graph build only considering the edges (and the involved nodes)
      * of a type contained in EtypeDAG must be a DAG. This reduction of the
@@ -68,17 +68,17 @@ public class RooterDAG {
      * href="http://en.wikipedia.org/wiki/Connectivity_(graph_theory)"> (more
      * about) </a> after processing if uDAG is already rooted no treatment
      * performed, specified root is not added and the current root URI is
-     * returned <br/> <br/>
+     * returned <br> <br>
      *
-     * Example <br/> <br/> input G a cyclic graph containing multiple taxonomic
-     * graphs (DAG considering SUPERCLASSOF/SUBCLASSOF relationships) <br/>
-     * EtypeDAG = SUPERCLASSOF <br/>
+     * Example <br> <br> input G a cyclic graph containing multiple taxonomic
+     * graphs (DAG considering SUPERCLASSOF/SUBCLASSOF relationships) <br>
+     * EtypeDAG = SUPERCLASSOF <br>
      *
      * uDAG the unconnected graph composed of the underlying taxonomic graphs
-     * <br/> invEtypeDAG = SUBCLASSOF <br/> roots : all uDAG graphs which are
-     * not subsumed by a vertex <br/> process -> add a subsuming vertex
+     * <br> invEtypeDAG = SUBCLASSOF <br> roots : all uDAG graphs which are
+     * not subsumed by a vertex <br> process → add a subsuming vertex
      * (rootURI) for each vertices in roots if the set of root is upper than 1
-     * (no unique root) <br/>
+     * (no unique root) <br>
      *
      * @param g the graph to root
      * @param wc the constraints associated to the walk.

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/validator/dag/Path.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/validator/dag/Path.java
@@ -41,7 +41,7 @@ import slib.graph.model.graph.elements.E;
  *
  * Simple representation of a path in a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Path {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/validator/dag/ValidatorDAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/extraction/validator/dag/ValidatorDAG.java
@@ -54,7 +54,7 @@ import slib.utils.impl.SetUtils;
 /**
  * Used to validate if a graph is directed and acyclic (DAG)
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ValidatorDAG {
 
@@ -234,7 +234,7 @@ public class ValidatorDAG {
 
     /**
      * Root vertices (terminal vertices) are those of type CLASS which respect
-     * the following restrictions :<br/> <ul> <li> must not contains an edges of
+     * the following restrictions :<br> <ul> <li> must not contains an edges of
      * the given types and direction </li> </ul>
      *
      * Do not check if the graph is a DAG

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/metric/DepthAnalyserAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/metric/DepthAnalyserAG.java
@@ -55,7 +55,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Class used to analyze depth of vertices composing an acyclic graph
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class DepthAnalyserAG {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/reduction/dag/GraphReduction_DAG_Ranwez_2011.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/reduction/dag/GraphReduction_DAG_Ranwez_2011.java
@@ -59,14 +59,14 @@ import slib.utils.impl.SetUtils;
 
 /**
  * Algorithm used to extract a subgraph from a DAG (Directed Acyclic Graph)
- * <br/> Implementation of Ranwez et al. 2011 algorithm. <br/>
- * original paper: <br/>
+ * <br> Implementation of Ranwez et al. 2011 algorithm. <br>
+ * original paper: <br>
  *
- * ﻿Ranwez V, Ranwez S, Janaqi S: Sub-Ontology Extraction Using Hyponym and
+ * Ranwez V, Ranwez S, Janaqi S: Sub-Ontology Extraction Using Hyponym and
  * Hypernym Closure on is-a Directed Acyclic Graphs. IEEE Transactions on
  * Knowledge and Data Engineering 2011, 99:1-14.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphReduction_DAG_Ranwez_2011 {
 
@@ -87,7 +87,7 @@ public class GraphReduction_DAG_Ranwez_2011 {
      * Method used to perform the subGraph extraction of an acyclic graph based
      * on top-down and bottom-up transitive closures.
      *
-     * The reduction is performed considering: <br/>
+     * The reduction is performed considering: <br>
      * <ul>
      * <li>
      * A set of URIs corresponding to the vertices on which must be based the

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/reduction/dag/GraphReduction_Transitive.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/reduction/dag/GraphReduction_Transitive.java
@@ -56,7 +56,7 @@ import slib.utils.impl.SetUtils;
  * Class used to perform a transitive reduction of a DAG see
  * http://en.wikipedia.org/wiki/Transitive_reduction
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class GraphReduction_Transitive {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/shortest_path/Dijkstra.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/shortest_path/Dijkstra.java
@@ -52,7 +52,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * href="http://en.wikipedia.org/wiki/Dijkstra's_algorithm">more about</a> TODO
  * optimize i.e Fibonacci heap implementation
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Dijkstra {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/GraphTraversal.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/GraphTraversal.java
@@ -38,7 +38,7 @@ import org.openrdf.model.URI;
 /**
  * GraphTraversal interface
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/classical/BFS.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/classical/BFS.java
@@ -55,7 +55,7 @@ import slib.utils.impl.SetUtils;
  * <a href="http://en.wikipedia.org/wiki/Breadth-first_search">more about
  * BFS</a>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class BFS implements GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/classical/DFS.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/traversal/classical/DFS.java
@@ -56,7 +56,7 @@ import slib.utils.impl.SetUtils;
  * creation. The iteration is then made on the stored topological sort. The
  * topological sort can also be retrieve.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class DFS implements GraphTraversal {

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/Color.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/Color.java
@@ -38,7 +38,7 @@ package slib.graph.algo.utils;
  * Enumeration used to represent colors.
  * Used for graph algorithms.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum Color {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GAction.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GAction.java
@@ -39,7 +39,7 @@ import slib.utils.impl.ParametrableImpl;
 /**
  * Class used to represent an action which is applicable to a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GAction extends ParametrableImpl implements CheckableValidity {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GActionType.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GActionType.java
@@ -37,7 +37,7 @@ package slib.graph.algo.utils;
  * Enumeration used to represent the various types of actions which can be
  * applied to a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum GActionType {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GActionValidator.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GActionValidator.java
@@ -36,7 +36,7 @@ package slib.graph.algo.utils;
 /**
  * Class used to validate if the configuration associated to a {@link GAction} is valid.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GActionValidator {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GraphActionExecutor.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/GraphActionExecutor.java
@@ -68,7 +68,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Class managing the execution of {@link GAction} over a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphActionExecutor {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/RooterDAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/utils/RooterDAG.java
@@ -49,14 +49,14 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Object used to root a graph taking into consideration edge types defining
  * roots.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class RooterDAG {
 
     /**
      * Add a unique root to a DAG (underlying DAG) composed of multiple roots.
-     * <br/> The processed graph must be/contains a DAG according to a specified
+     * <br> The processed graph must be/contains a DAG according to a specified
      * set of edge type here called EtypeDAG. In other words the reduction of
      * the given graph build only considering the edges (and the involved nodes)
      * of a type contained in EtypeDAG must be a DAG. This reduction of the
@@ -68,17 +68,17 @@ public class RooterDAG {
      * href="http://en.wikipedia.org/wiki/Connectivity_(graph_theory)"> (more
      * about) </a> after processing if uDAG is already rooted no treatment
      * performed, specified root is not added and the current root URI is
-     * returned <br/> <br/>
+     * returned <br> <br>
      *
-     * Example <br/> <br/> input G a cyclic graph containing multiple taxonomic
-     * graphs (DAG considering SUPERCLASSOF/SUBCLASSOF relationships) <br/>
-     * EtypeDAG = SUPERCLASSOF <br/>
+     * Example <br> <br> input G a cyclic graph containing multiple taxonomic
+     * graphs (DAG considering SUPERCLASSOF/SUBCLASSOF relationships) <br>
+     * EtypeDAG = SUPERCLASSOF <br>
      *
      * uDAG the unconnected graph composed of the underlying taxonomic graphs
-     * <br/> invEtypeDAG = SUBCLASSOF <br/> roots : all uDAG graphs which are
-     * not subsumed by a vertex <br/> process -> add a subsuming vertex
+     * <br> invEtypeDAG = SUBCLASSOF <br> roots : all uDAG graphs which are
+     * not subsumed by a vertex <br> process → add a subsuming vertex
      * (rootURI) for each vertices in roots if the set of root is upper than 1
-     * (no unique root) <br/>
+     * (no unique root) <br>
      *
      * @param g the graph to root
      * @param wc the constraints associated to the walk.

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/validator/dag/Path.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/validator/dag/Path.java
@@ -41,7 +41,7 @@ import slib.graph.model.graph.elements.E;
  *
  * Simple representation of a path in a graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Path {
 

--- a/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/validator/dag/ValidatorDAG.java
+++ b/slib-graph/slib-graph-algo/src/main/java/slib/graph/algo/validator/dag/ValidatorDAG.java
@@ -54,7 +54,7 @@ import slib.utils.impl.SetUtils;
 /**
  * Used to validate if a graph is directed and acyclic (DAG)
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ValidatorDAG {
 
@@ -234,7 +234,7 @@ public class ValidatorDAG {
 
     /**
      * Root vertices (terminal vertices) are those of type CLASS which respect
-     * the following restrictions :<br/> <ul> <li> must not contains an edges of
+     * the following restrictions :<br> <ul> <li> must not contains an edges of
      * the given types and direction </li> </ul>
      *
      * Do not check if the graph is a DAG

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/conf/GDataConf.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/conf/GDataConf.java
@@ -40,7 +40,7 @@ import slib.utils.impl.ParametrableImpl;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GDataConf extends ParametrableImpl implements CheckableValidity {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/conf/GraphConf.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/conf/GraphConf.java
@@ -42,7 +42,7 @@ import slib.utils.impl.ParametrableImpl;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphConf extends ParametrableImpl implements CheckableValidity, Comparable<Object> {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/GraphLoader.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/GraphLoader.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Generic interface defining the methods a graph loader must implements
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface GraphLoader {

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/GraphLoaderGeneric.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/GraphLoaderGeneric.java
@@ -65,7 +65,7 @@ import slib.utils.ex.SLIB_Exception;
  *
  * Graph Loader is a class used to facilitate graph loading.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoaderGeneric {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/annot/GraphLoader_TSVannot.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/annot/GraphLoader_TSVannot.java
@@ -59,13 +59,13 @@ import slib.utils.impl.Util;
  *
  * To each line is associated an entry defining a key and a set of annotations
  * separated by ';'. As an example the first line XXXX1[TAB]c1;c2;c3 will lead
- * to the creation of three statements: XXXXX1 RDF.TYPE c1 <br/>
- * XXXXX1 RDF.TYPE c2 <br/>
- * XXXXX1 RDF.TYPE c3 <br/>
+ * to the creation of three statements: XXXXX1 RDF.TYPE c1 <br>
+ * XXXXX1 RDF.TYPE c2 <br>
+ * XXXXX1 RDF.TYPE c3 <br>
  * By default the semantic relationship is RDF.TYPE. Prefixes can also be
  * defined for the subjects and the objects of the statements created.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_TSVannot implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/gaf2/EvidenceCodeRules.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/gaf2/EvidenceCodeRules.java
@@ -70,7 +70,7 @@ import java.util.Set;
  * Curator Statement Evidence Codes IC: Inferred by Curator ND: No biological
  * Data available
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class EvidenceCodeRules {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/gaf2/GraphLoader_GAF_2.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/gaf2/GraphLoader_GAF_2.java
@@ -62,7 +62,7 @@ import slib.utils.impl.BigFileReader;
  *
  * TODO - Manage multiple organism specification : taxon:1|taxon:1000
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_GAF_2 implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/GraphLoader_MESH_XML.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/GraphLoader_MESH_XML.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.bio.mesh;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 import java.io.IOException;
 import java.util.HashMap;
@@ -72,7 +72,7 @@ import slib.utils.ex.SLIB_Exception;
  * The loader was designed for the 2013 XML version of the MeSH, coherency with
  * prior or older version hasn't been tested.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_MESH_XML implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/MeshConcept.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/MeshConcept.java
@@ -39,7 +39,7 @@ import java.util.Set;
 /**
  * Dummy representation of a Mesh Concept
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeshConcept{
     

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/MeshXMLHandler.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/mesh/MeshXMLHandler.java
@@ -39,7 +39,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeshXMLHandler extends DefaultHandler {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/GraphLoader_OBO_1_2.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/GraphLoader_OBO_1_2.java
@@ -64,67 +64,67 @@ import slib.utils.impl.OBOconstants;
 
 /**
  * <a href="http://www.geneontology.org/GO.format.obo-1_2.shtml">OBO
- * specification</a> <br/>
+ * specification</a> <br>
  *
- * Compatibility with other format-version than 1.2 is not supported. <br/>
+ * Compatibility with other format-version than 1.2 is not supported. <br>
  *
- * <b> The mapping consider </b> <br/> <ul> <li>[Term] as RDF/OWL class mapping
+ * <b> The mapping consider </b> <br> <ul> <li>[Term] as RDF/OWL class mapping
  * to build vertices </li> <li>[Typedef] as relationships definitions between
  * nodes </li> <li>"is_a" as the only predefined relationType </li>
- * <li>[instance] are not loaded </li> </ul> Meta informations: <br/> <ul> <li>
+ * <li>[instance] are not loaded </li> </ul> Meta informations: <br> <ul> <li>
  * format-version : Only required argument of the specification expect 1.2 throw
- * non warning exception (<SGTK_Exception_Warning>) if 1.2 version is not
+ * non warning exception ([SGTK_Exception_Warning]) if 1.2 version is not
  * detected </li> <li> default-namespace: the graph URI </li> </ul>
  *
- * <b> [Term] </b>	<br/>
+ * <b> [Term] </b>	<br>
  *
- * Each Term are loaded as a specific vertex in the graph. <br/> A Term is then
- * mapped as a <Vertex> of <IVertexType> equals to <Constants> V_TYPE_CLASS.
- * <br/> Note that obsolete Terms/Typedefs are excluded during graph
- * construction (see below is_obsolete). <br/> <br/>
+ * Each Term is loaded as a specific vertex in the graph. <br> A Term is then
+ * mapped as a [Vertex] of [IVertexType] equal to [Constants] V_TYPE_CLASS. <br>
+ * Note that obsolete Terms/Typedefs are excluded during graph construction
+ * (see below is_obsolete). <br> <br>
  *
- * Flag considered : <br/>
+ * Flag considered : <br>
  *
- * <ul> <li> id: <URI> Loaded as the URI of the current [Term/Class/Vertex]
- * specification </li> <li> is a: <URI> Loaded as an <Edge> of <EdgeType>
- * <Constants> IS_A with currently defined Vertex as source and specified <URI>
- * as target Vertex </li> <li> relationships: <EdgeType> <URI> Loaded as an
- * <Edge> of specified <EdgeType> with source as current Vertex and target
- * specified by the precise <URI> The EdgeType have to be defined by a [TypeDef]
+ * <ul> <li> id: [URI] Loaded as the URI of the current [Term/Class/Vertex]
+ * specification </li> <li> is a: [URI] Loaded as an [Edge] of [EdgeType]
+ * [Constants] IS_A with currently defined Vertex as source and specified [URI]
+ * as target Vertex </li> <li> relationships: [EdgeType] [URI] Loaded as an
+ * [Edge] of specified [EdgeType] with source as current Vertex and target
+ * specified by the precise [URI] The EdgeType have to be defined by a [TypeDef]
  * specification to be taken into account. </li>
  *
- * <li> is_obsolete: <boolean> Specifying the validity of the current Term
+ * <li> is_obsolete: [boolean] Specifying the validity of the current Term
  * specification </li> <li> intersection_of/XREF...: These information are not
  * loaded. </li> </ul>
  *
- * <b>	[Typedef] as <EdgeType> </b> <br/>
+ * <b>	[Typedef] as [EdgeType] </b> <br>
  *
- * Every Typedef definition is loaded as an <EdgeType>. <br/> This definition is
- * used to specify the type authorized for <Edge> specification <br/>
+ * Every Typedef definition is loaded as an [EdgeType]. <br> This definition is
+ * used to specify the type authorized for [Edge] specification <br>
  *
- * <ul> <li> id: <URI> the URI of the <EdgeType> </li>
+ * <ul> <li> id: [URI] the URI of the [EdgeType] </li>
  *
- * <li> is_transitive: <boolean> Specifying if the relationship have to be
+ * <li> is_transitive: [boolean] Specifying if the relationship have to be
  * considered as transitive </li>
  *
- * <li> inverse_of <URI> Used to defined the URI of the <EdgeType> to consider
+ * <li> inverse_of [URI] Used to defined the URI of the [EdgeType] to consider
  * as the inverse of the current specified EdgeType e.g if an edge type X is
  * defined as the inverse of Y, a relationship of type X defined between A and B
- * will lead to the creation of: <ul> <li> an edge of type X betwween v(A) ->
- * v(B) </li> <li> an edge of type Y betwween v(B) -> v(A) </li> </ul> </li>
+ * will lead to the creation of: <ul> <li> an edge of type X betwween v(A) →
+ * v(B) </li> <li> an edge of type Y betwween v(B) → v(A) </li> </ul> </li>
  *
- * <li> is_symmetric <boolean> Used to defined an EdgeType as the inverse of
+ * <li> is_symmetric [boolean] Used to defined an EdgeType as the inverse of
  * itself e.g if an edge type X is transitive, a relationship defined as an edge
- * of type X betwween v(A) -> v(B) is defined will imply the creation of an edge
- * of type X as v(B) -> v(A) </li>
+ * of type X betwween v(A) → v(B) is defined will imply the creation of an edge
+ * of type X as v(B) → v(A) </li>
  *
- * <li> is_obsolete: <boolean> Specifying the validity of the current Typedef
+ * <li> is_obsolete: [boolean] Specifying the validity of the current Typedef
  * specification </li>
  *
  * <li> transitive_over/XREF...: These information are not loaded. </li> </ul>
  * TODO : load instances
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_OBO_1_2 implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboRelationship.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboRelationship.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.bio.obo.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OboRelationship {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboTerm.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboTerm.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OboTerm {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboType.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/obo/utils/OboType.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.bio.obo.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OboType {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/snomedct/GraphLoaderSnomedCT_RF2.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/bio/snomedct/GraphLoaderSnomedCT_RF2.java
@@ -58,7 +58,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 import slib.utils.ex.SLIB_Exception;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoaderSnomedCT_RF2 implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_Mapping.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_Mapping.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.csv;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class CSV_Mapping {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_StatementTemplate.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_StatementTemplate.java
@@ -40,7 +40,7 @@ import org.openrdf.model.URI;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class CSV_StatementTemplate {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_StatementTemplate_Constraint.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/CSV_StatementTemplate_Constraint.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.csv;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class CSV_StatementTemplate_Constraint {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/GraphLoader_CSV.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/GraphLoader_CSV.java
@@ -57,7 +57,7 @@ import slib.utils.impl.Util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_CSV implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/StatementTemplateElement.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/StatementTemplateElement.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.csv;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum StatementTemplateElement {
 	/**

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/StatementTemplate_Constraint_Type.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/csv/StatementTemplate_Constraint_Type.java
@@ -35,7 +35,7 @@ package slib.graph.io.loader.csv;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum StatementTemplate_Constraint_Type {
 	/**

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/rdf/RDFLoader.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/rdf/RDFLoader.java
@@ -62,7 +62,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class RDFLoader implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/rdf/SlibRdfHandler.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/rdf/SlibRdfHandler.java
@@ -46,7 +46,7 @@ import slib.graph.model.repo.URIFactory;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SlibRdfHandler implements RDFHandler {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/slibformat/GraphLoader_SLIB.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/slibformat/GraphLoader_SLIB.java
@@ -55,7 +55,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * TODO Comment DO not Support transitivity and inverse definitions anymore
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class GraphLoader_SLIB implements GraphLoader {

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/Filter.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/Filter.java
@@ -38,7 +38,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Filter {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/FilterCst.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/FilterCst.java
@@ -38,7 +38,7 @@ import slib.graph.io.loader.utils.filter.graph.metrics.FilterGraph_Metrics_cst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterCst {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/FilterGraph.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/FilterGraph.java
@@ -38,7 +38,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterGraph extends Filter{
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/gaf2/FilterGraph_GAF2.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/gaf2/FilterGraph_GAF2.java
@@ -43,7 +43,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterGraph_GAF2 extends FilterGraph {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/gaf2/FilterGraph_GAF2_cst.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/gaf2/FilterGraph_GAF2_cst.java
@@ -38,7 +38,7 @@ package slib.graph.io.loader.utils.filter.graph.gaf2;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterGraph_GAF2_cst{
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/metrics/FilterGraph_Metrics.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/metrics/FilterGraph_Metrics.java
@@ -39,7 +39,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterGraph_Metrics extends FilterGraph {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/metrics/FilterGraph_Metrics_cst.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/metrics/FilterGraph_Metrics_cst.java
@@ -37,7 +37,7 @@ package slib.graph.io.loader.utils.filter.graph.metrics;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterGraph_Metrics_cst{
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/repo/FilterRepository.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/utils/filter/graph/repo/FilterRepository.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterRepository {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/wordnet/GraphLoader_Wordnet.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/loader/wordnet/GraphLoader_Wordnet.java
@@ -56,7 +56,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphLoader_Wordnet implements GraphLoader {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/plotter/GraphPlotter_Graphviz.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/plotter/GraphPlotter_Graphviz.java
@@ -47,7 +47,7 @@ import slib.graph.model.repo.URIFactory;
 /**
  * Class used to plot graph using Graphviz.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class GraphPlotter_Graphviz {

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GActionValidator.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GActionValidator.java
@@ -37,7 +37,7 @@ import slib.graph.algo.utils.GAction;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GActionValidator {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GDataValidator.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GDataValidator.java
@@ -37,7 +37,7 @@ import slib.graph.io.conf.GDataConf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GDataValidator {
 

--- a/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GFormat.java
+++ b/slib-graph/slib-graph-io/src/main/java/slib/graph/io/util/GFormat.java
@@ -35,7 +35,7 @@ package slib.graph.io.util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum GFormat {
 

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/elements/Edge.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/elements/Edge.java
@@ -40,7 +40,7 @@ import slib.graph.model.graph.elements.E;
  * Implementation of the {@link E} interface.
  * @see E
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Edge implements E {
 

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/memory/GraphMemory.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/memory/GraphMemory.java
@@ -49,7 +49,7 @@ import slib.graph.model.impl.graph.elements.Edge;
 /**
  * In memory implementation of {@link G}
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphMemory implements G {
 

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/weight/GWS_impl.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/graph/weight/GWS_impl.java
@@ -44,7 +44,7 @@ import slib.graph.model.graph.weight.GWS;
 /**
  * In memory Graph Weighting Scheme (GWS) implementation of {@link GWS}
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class GWS_impl implements GWS {

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/repo/GraphRepositoryMemory.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/repo/GraphRepositoryMemory.java
@@ -41,7 +41,7 @@ import slib.graph.model.repo.GraphRepository;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphRepositoryMemory implements GraphRepository {
 

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/repo/URIFactoryMemory.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/repo/URIFactoryMemory.java
@@ -58,7 +58,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * in a graph are linked to the corresponding storage element in the Data
  * repository. All change of the graph must be propagated on the Data Repository
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public final class URIFactoryMemory implements URIFactory {

--- a/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/utils/GraphUtils.java
+++ b/slib-graph/slib-graph-model-impl/src/main/java/slib/graph/model/impl/utils/GraphUtils.java
@@ -48,7 +48,7 @@ import slib.graph.model.repo.URIFactory;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GraphUtils {
 

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/G.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/G.java
@@ -66,7 +66,7 @@ import slib.graph.model.graph.utils.WalkConstraint;
  * @see Direction
  * @see WalkConstraint
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface G {
 

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/elements/E.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/elements/E.java
@@ -45,7 +45,7 @@ import org.openrdf.model.URI;
  * source, the target and the predicate of the edge. Moreover the aforementioned 
  * elements must not be null.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface E {
 

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/utils/Direction.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/utils/Direction.java
@@ -36,14 +36,14 @@ package slib.graph.model.graph.utils;
 /**
  * Enumeration used to characterized the Direction of an edge.
  * <ul>
- * <li>IN: an edge x -> y is an IN edge of y, i.e. the edge is an incoming edge
+ * <li>IN: an edge x → y is an IN edge of y, i.e. the edge is an incoming edge
  * of y </li>
- * <li>OUT: an edge x -> y is an OUT edge of x, i.e. the edge is an out coming
+ * <li>OUT: an edge x → y is an OUT edge of x, i.e. the edge is an out coming
  * edge of x </li>
  * <li>BOTH: both IN and OUT direction are considered</li>
  * </ul>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum Direction {
 

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/utils/WalkConstraint.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/utils/WalkConstraint.java
@@ -47,7 +47,7 @@ import slib.graph.model.graph.elements.E;
  * <li>the direction of the edges</li>
  * </ul>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface WalkConstraint {

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/weight/GWS.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/graph/weight/GWS.java
@@ -52,7 +52,7 @@ import slib.graph.model.graph.elements.E;
  *
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface GWS {

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/repo/GraphRepository.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/repo/GraphRepository.java
@@ -39,7 +39,7 @@ import slib.graph.model.graph.G;
 /**
  * Interface defining a repository for the graphs.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface GraphRepository {
 

--- a/slib-graph/slib-graph-model/src/main/java/slib/graph/model/repo/URIFactory.java
+++ b/slib-graph/slib-graph-model/src/main/java/slib/graph/model/repo/URIFactory.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Interface defining a Factory which must be used to create the URIs or namespace.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface URIFactory{

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/SLIB_UnitTestValues.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/SLIB_UnitTestValues.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SLIB_UnitTestValues {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/TestSetUtils.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/TestSetUtils.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestSetUtils {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/TestUtils.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/TestUtils.java
@@ -43,7 +43,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestUtils {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/extraction/TestReachableVerticesFinder.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/extraction/TestReachableVerticesFinder.java
@@ -54,7 +54,7 @@ import slib.utils.impl.SetUtils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestReachableVerticesFinder {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/metric/TestDepthAnalyser.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/metric/TestDepthAnalyser.java
@@ -52,7 +52,7 @@ import slib.graph.utils.WalkConstraintGeneric;
 import slib.utils.ex.SLIB_Exception;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestDepthAnalyser {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/reduction/dag/Test_GraphReduction_Transitive.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/reduction/dag/Test_GraphReduction_Transitive.java
@@ -63,7 +63,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Test_GraphReduction_Transitive {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/shortest_path/Test_Shortest_path.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/shortest_path/Test_Shortest_path.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Test_Shortest_path {
 

--- a/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/validator/dag/TestValidatorDAG.java
+++ b/slib-graph/slib-graph-test/src/test/java/slib/graph/test/algo/graph/validator/dag/TestValidatorDAG.java
@@ -56,7 +56,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestValidatorDAG {
 

--- a/slib-graph/slib-graph-utils/src/main/java/slib/graph/utils/WalkConstraintGeneric.java
+++ b/slib-graph/slib-graph-utils/src/main/java/slib/graph/utils/WalkConstraintGeneric.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
  *
  * Class used to facilitate the use of WalkConstraint over graph.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class WalkConstraintGeneric implements WalkConstraint {
 

--- a/slib-graph/slib-graph-utils/src/main/java/slib/graph/utils/WalkConstraintUtils.java
+++ b/slib-graph/slib-graph-utils/src/main/java/slib/graph/utils/WalkConstraintUtils.java
@@ -41,7 +41,7 @@ import slib.graph.model.graph.utils.WalkConstraint;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class WalkConstraintUtils {
 
@@ -53,7 +53,7 @@ public class WalkConstraintUtils {
      * <ul>
      * <li>Accepted Predicate are unchanged</li>
      * <li>Direction associated to accepted predicate are the inverse of those
-     * defined: IN -> OUT, OUT -> IN, BOTH -> BOTH (if boolean
+     * defined: IN → OUT, OUT → IN, BOTH → BOTH (if boolean
      * includeBOTHpredicate is set to true)
      * </li>
      * </ul>

--- a/slib-indexer/src/main/java/slib/indexer/IndexHash.java
+++ b/slib-indexer/src/main/java/slib/indexer/IndexHash.java
@@ -42,7 +42,7 @@ import org.openrdf.model.URI;
  * as String values. This class is therefore mainly used to store labels or
  * string descriptions of a resource identified by an URI.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IndexHash {
 

--- a/slib-indexer/src/main/java/slib/indexer/URIDescription.java
+++ b/slib-indexer/src/main/java/slib/indexer/URIDescription.java
@@ -43,7 +43,7 @@ import org.openrdf.model.URI;
  * are mainly used to store and access the labels or descriptions associated to
  * a resource.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface URIDescription {
 

--- a/slib-indexer/src/main/java/slib/indexer/URIDescriptionBasic.java
+++ b/slib-indexer/src/main/java/slib/indexer/URIDescriptionBasic.java
@@ -42,7 +42,7 @@ import org.openrdf.model.URI;
 /**
  * In-memory implementation of the interface URIDescription
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public final class URIDescriptionBasic implements URIDescription {
 

--- a/slib-indexer/src/main/java/slib/indexer/mesh/Indexer_MESH_XML.java
+++ b/slib-indexer/src/main/java/slib/indexer/mesh/Indexer_MESH_XML.java
@@ -35,7 +35,7 @@ package slib.indexer.mesh;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 import java.io.IOException;
 import java.util.HashMap;
@@ -58,7 +58,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Class used to build an index for the descriptors specified in the MeSH XML.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Indexer_MESH_XML {
 

--- a/slib-indexer/src/main/java/slib/indexer/mesh/MeshDescriptor.java
+++ b/slib-indexer/src/main/java/slib/indexer/mesh/MeshDescriptor.java
@@ -39,7 +39,7 @@ import java.util.Set;
 /**
  * Simple representation of a Mesh Descriptor
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeshDescriptor {
 

--- a/slib-indexer/src/main/java/slib/indexer/mesh/MeshXMLHandler.java
+++ b/slib-indexer/src/main/java/slib/indexer/mesh/MeshXMLHandler.java
@@ -40,7 +40,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MeshXMLHandler extends DefaultHandler {
 

--- a/slib-indexer/src/main/java/slib/indexer/obo/IndexerOBO.java
+++ b/slib-indexer/src/main/java/slib/indexer/obo/IndexerOBO.java
@@ -50,7 +50,7 @@ import slib.utils.impl.OBOconstants;
 /**
  * Class used to build an index for the terms specified in an OBO ontology
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IndexerOBO {
 

--- a/slib-indexer/src/main/java/slib/indexer/snomed_ct/IndexerSNOMEDCT_RF2.java
+++ b/slib-indexer/src/main/java/slib/indexer/snomed_ct/IndexerSNOMEDCT_RF2.java
@@ -53,7 +53,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IndexerSNOMEDCT_RF2 {
 

--- a/slib-indexer/src/main/java/slib/indexer/wordnet/IndexerWordNetBasic.java
+++ b/slib-indexer/src/main/java/slib/indexer/wordnet/IndexerWordNetBasic.java
@@ -54,7 +54,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  *
  * DUMMY INDEXER USED TO DEBUG. INPUT: index.*
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IndexerWordNetBasic {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/engine/SMProxResultStorage.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/engine/SMProxResultStorage.java
@@ -43,7 +43,7 @@ import slib.sml.sm.core.utils.SMconf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMProxResultStorage {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/engine/SM_Engine.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/engine/SM_Engine.java
@@ -88,7 +88,7 @@ import slib.utils.impl.SetUtils;
 /**
  * This class defines a Semantic Measures Engine which gives access to several
  * methods commonly used to define ontology-based semantic measures.
- * <br/>
+ * <br>
  * The engine distinguished two types of vertices in the graph:
  * <ul>
  * <li>
@@ -115,7 +115,7 @@ import slib.utils.impl.SetUtils;
  * an ancestors is any class which is link by a path composed of RDFS.SUBCLASSOF
  * relationships.
  *
- * <br/><b>Important</b>:<br/>
+ * <br><b>Important</b>:<br>
  * Note that the graph associated to the engine is expected to be immutable even
  * if this condition will not be checked during the process. Indeed, the engine
  * expects the graph not to be modified and will not work on a copy of the given
@@ -133,7 +133,7 @@ import slib.utils.impl.SetUtils;
  * The engine stores commonly accessed results (e.g. ancestors of a class) which
  * can lead to high memory consumption dealing with large graphs.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SM_Engine {
 
@@ -293,7 +293,7 @@ public class SM_Engine {
     /**
      * Get the parents of a class, that is to say its direct ancestors.
      *
-     * <br/><b>Important</b>:<br/>
+     * <br><b>Important</b>:<br>
      *
      * The direct parent of a class are all classes x linked to the given class
      * c to a an edge x RDFS.SUBLASSOF c. The result is not cached by the
@@ -1061,7 +1061,7 @@ public class SM_Engine {
      * Set the configuration of the engine regarding pairwise semantic measure
      * score caching.
      *
-     * <br/><b>Important</b>:<br/>
+     * <br><b>Important</b>:<br>
      *
      * Storing the results can be very useful in specific cases. However,
      * storing the results can also lead to high memory consumption and
@@ -1132,8 +1132,9 @@ public class SM_Engine {
     }
 
     /**
-     * TODO store the weighting scheme in a Map<String,GWS> Provide a way to
-     * load edge weight from file or to compute them using specific methods
+     * TODO store the weighting scheme in a {@code Map<String,GWS>}, provide a
+     * way to load edge weight from file or to compute them using specific
+     * methods
      *
      * @param param the key corresponding to the id of the weighting scheme to
      * retrieve

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Dist_Pairwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Dist_Pairwise.java
@@ -37,7 +37,7 @@ package slib.sml.sm.core.measures;
  * Interface used to represent a pairwise measure which can be used to compute
  * the semantic similarity of a pair of concepts/classes.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Dist_Pairwise implements IDist_Pairwise {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/IDist_Pairwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/IDist_Pairwise.java
@@ -37,6 +37,6 @@ package slib.sml.sm.core.measures;
  * Interface used to represent a pairwise measure which can be used to compute
  * the semantic similarity of a pair of concepts/classes.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface IDist_Pairwise extends Measure_Pairwise {}

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/ISim_Pairwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/ISim_Pairwise.java
@@ -37,6 +37,6 @@ package slib.sml.sm.core.measures;
  * Interface used to represent a pairwise measure which can be used to compute
  * the semantic similarity of a pair of concepts/classes.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface ISim_Pairwise extends Measure_Pairwise {}

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/MConstant.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/MConstant.java
@@ -36,7 +36,7 @@ package slib.sml.sm.core.measures;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MConstant {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/MType.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/MType.java
@@ -36,7 +36,7 @@ package slib.sml.sm.core.measures;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum MType {
     SIMILARITY,DISTANCE;

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure.java
@@ -37,7 +37,7 @@ package slib.sml.sm.core.measures;
  *
  * Generic interface of a measure which can be used to compare two objects.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface Measure {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure_Groupwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure_Groupwise.java
@@ -41,7 +41,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface Measure_Groupwise extends Measure {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure_Pairwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Measure_Pairwise.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface Measure_Pairwise extends Measure {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise.java
@@ -36,7 +36,7 @@ package slib.sml.sm.core.measures;
 /**
  * Interface used to represent Semantic similarity used to process pairs of groups of vertices.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Groupwise implements Measure_Groupwise{
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise_Direct.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise_Direct.java
@@ -37,6 +37,6 @@ package slib.sml.sm.core.measures;
  * Interface used to represent direct groupwise measures. Those measures do not
  * rely on a pairwise measure to compute the likeness of two group of concepts.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Groupwise_Direct extends Sim_Groupwise {}

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise_Indirect.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Groupwise_Indirect.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Those measures rely on the aggregation of the scores produced by pairwise
  * measures and are therefore considered as indirect in the literature.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Groupwise_Indirect extends Sim_Groupwise {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Pairwise.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/Sim_Pairwise.java
@@ -37,7 +37,7 @@ package slib.sml.sm.core.measures;
  * Interface used to represent a pairwise measure which can be used to compute
  * the semantic similarity of a pair of concepts/classes.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Pairwise implements ISim_Pairwise {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/Matrix.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/Matrix.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  * @param <R>
  * @param <C>
  */

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/MatrixType.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/MatrixType.java
@@ -35,7 +35,7 @@ package slib.sml.sm.core.measures.corpus;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum MatrixType {
     WORD_WORD, WORD_DOC;

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/VocContextMatrixBuilder.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/corpus/VocContextMatrixBuilder.java
@@ -51,7 +51,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class VocContextMatrixBuilder {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Bader_2003.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Bader_2003.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
  * in protein-protein interaction network. in Knowledge Discovery in
  * Bioinformatics: Techniques, Methods and Application 2006.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_Framework_DAG_Set_Bader_2003 extends Sim_Framework_DAG_Set_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Batet_2010.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Batet_2010.java
@@ -50,7 +50,7 @@ import slib.utils.impl.SetUtils;
  * order to produce results [0,1]. ﻿Faria D, Pesquita C, Couto FM, Falcão A:
  * Proteinon: A web tool for protein semantic similarity. 2007.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Batet_2010 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Braun_Blanquet_1932.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Braun_Blanquet_1932.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Braun-Blanquet J: Plant sociology: the study of plant communities.
  * McGraw-Hill; 1932:439.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Braun_Blanquet_1932 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Dice_1945.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Dice_1945.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Dice LR: Measures of the Amount of Ecologic Association Between Species.
  * Ecology 1945, 26:297-302.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_Framework_DAG_Set_Dice_1945 extends Sim_Framework_DAG_Set_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Jaccard_1901.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Jaccard_1901.java
@@ -44,7 +44,7 @@ import slib.utils.impl.SetUtils;
  * quelques regions voisines. Bulletin de la Societe Vaudoise des Sciences
  * Naturelles 1901, 37:241 - 272.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_Framework_DAG_Set_Jaccard_1901 extends Sim_Framework_DAG_Set_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Knappe_2004.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Knappe_2004.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Knappe R, Bulskov H, Andreasen T: Perspectives on ontology-based
  * querying. International Journal of Intelligent Systems 2004, 22:739-761.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Knappe_2004 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Korbel_2002.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Korbel_2002.java
@@ -46,7 +46,7 @@ import slib.utils.impl.SetUtils;
  * Cited by ﻿1. Lin C, Cho Y-rae, Hwang W-chang, Pei P, Zhang A: Clustering
  * methods in protein-protein interaction network.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_Framework_DAG_Set_Korbel_2002 extends Sim_Framework_DAG_Set_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Maryland_Bridge_2003.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Maryland_Bridge_2003.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
  * Meetings on Bioconsensus: October 25-26, 2000 and October 2-5, 2001, DIMACS
  * Center. Amer Mathematical Society; 2003, 61:97.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_Framework_DAG_Set_Maryland_Bridge_2003 extends Sim_Framework_DAG_Set_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Ochiai_1957.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Ochiai_1957.java
@@ -44,7 +44,7 @@ import slib.utils.impl.SetUtils;
  * its neighbouring regions. Bulletin of the Japanese Society of Scientific
  * Fischeries 1957, 22:526-530.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Ochiai_1957 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Simpson_1960.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Simpson_1960.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Simpson GG: Notes on the measurement of faunal resemblance. American
  * Journal of Science 1960, 258A:300-311.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Simpson_1960 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Sokal_Sneath_1963.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Sokal_Sneath_1963.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Sokal RR, Sneath PHA: Principles of numerical taxonomy. San Francisco:
  * W. H. Freeman and Company; 1963:359.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Sokal_Sneath_1963 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Tversky_1977.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_Tversky_1977.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
  * Tversky A: Features of similarity. Psychological Review 1977, 84:327-352.
  * Implementation of the contrast model in a set-based manner.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_Framework_DAG_Set_Tversky_1977 extends Sim_Framework_DAG_Set_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/framework/dag/Sim_Framework_DAG_Set_abstract.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Abstract class used to facilitate implementation of set based measures.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Framework_DAG_Set_abstract extends Sim_Groupwise_Direct implements ISim_Pairwise_DAG{
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_Ali_Deane.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_Ali_Deane.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
  *
  * Measures also know through the name Funsim.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_Ali_Deane extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_GIC.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_GIC.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
  * Pesquita C, Faria D, Bastos H: Evaluating gobased semantic similarity
  * measures. Proc. 10th Annual Bio- 2007:1-4.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_GIC extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_LP.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_LP.java
@@ -54,7 +54,7 @@ import slib.utils.impl.SetUtils;
  *
  * We understand the depth of the deepest lca of each entity couples.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_DAG_LP extends Sim_groupwise_DAG_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_Lee_2004.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_Lee_2004.java
@@ -43,7 +43,7 @@ import slib.utils.impl.SetUtils;
  * Lee HK, Hsu AK, Sajdak J, Qin J, Pavlidis P: Coexpression analysis of human
  * genes across many microarray data sets. Genome Research 2004, 14:1085.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_Lee_2004 extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_NTO.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_NTO.java
@@ -44,7 +44,7 @@ import slib.utils.impl.SetUtils;
  * ﻿Mistry M, Pavlidis P: Gene Ontology term overlap as a measure of gene
  * functional similarity. BMC bioinformatics 2008, 9:327.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_NTO extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_NTO_MAX.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_NTO_MAX.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
  *
  * The maximum of the cardinality of the denominator is used in this version.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_NTO_MAX extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_TO.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_TO.java
@@ -47,7 +47,7 @@ import slib.utils.impl.SetUtils;
  * the set of vertices composing the graph build from the intersection of the
  * graphs induced by the ancestors of the two given sets of concepts.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_DAG_TO extends Sim_groupwise_DAG_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_UI.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_UI.java
@@ -44,7 +44,7 @@ import slib.utils.impl.SetUtils;
  * Gentleman R: Visualizing and distances using GO. Retrieved Jan. 10th 2007.
  * http://www.bioconductor.org/packages/release/bioc/vignettes/GOstats/inst/doc/GOvis.pdf
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_DAG_UI extends Sim_groupwise_DAG_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/groupwise/dag/Sim_groupwise_DAG_abstract.java
@@ -39,7 +39,7 @@ import slib.sml.sm.core.measures.Sim_Groupwise_Direct;
  * Abstract class used to represent a semantic measure which can be applied
  * between two sets of concepts expressed in a Directed Acyclic Graph (DAG).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_groupwise_DAG_abstract extends Sim_Groupwise_Direct {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/Dist_Pairwise_DAG.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/Dist_Pairwise_DAG.java
@@ -37,7 +37,7 @@ import slib.sml.sm.core.measures.Dist_Pairwise;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Dist_Pairwise_DAG extends Dist_Pairwise implements IDist_Pairwise_DAG {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/IDist_Pairwise_DAG.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/IDist_Pairwise_DAG.java
@@ -41,7 +41,7 @@ import slib.sml.sm.core.measures.ISim_Pairwise;
  * semantic similarity of two classes/concepts structured in a Directed Acyclic
  * Graph (DAG).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface IDist_Pairwise_DAG extends IDist_Pairwise {
 }

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/ISim_Pairwise_DAG.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/ISim_Pairwise_DAG.java
@@ -40,7 +40,7 @@ import slib.sml.sm.core.measures.ISim_Pairwise;
  * semantic similarity of two classes/concepts structured in a Directed Acyclic
  * Graph (DAG).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface ISim_Pairwise_DAG extends ISim_Pairwise {
 }

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/Sim_Pairwise_DAG.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/Sim_Pairwise_DAG.java
@@ -37,7 +37,7 @@ import slib.sml.sm.core.measures.Sim_Pairwise;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_Pairwise_DAG extends Sim_Pairwise implements ISim_Pairwise_DAG {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Dist_DAG_edge_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Dist_DAG_edge_abstract.java
@@ -41,7 +41,7 @@ import slib.sml.sm.core.measures.graph.pairwise.dag.Sim_Pairwise_DAG;
  * Class used to represent a {@link Sim_Pairwise_DAG} which relies on a
  * edge-based approach.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Dist_DAG_edge_abstract extends Dist_Pairwise_DAG {}
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_DAG_edge_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_DAG_edge_abstract.java
@@ -40,7 +40,7 @@ import slib.sml.sm.core.measures.graph.pairwise.dag.Sim_Pairwise_DAG;
  * Class used to represent a {@link Sim_Pairwise_DAG} which relies on a
  * edge-based approach.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_DAG_edge_abstract extends Sim_Pairwise_DAG {}
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Kyogoku_basic_2011.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Kyogoku_basic_2011.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Exception;
  *
  * Basic because Kyogoku propose a method to estimate edge weight
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_edge_Kyogoku_basic_2011 extends Sim_DAG_edge_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Leacock_Chodorow_1998.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Leacock_Chodorow_1998.java
@@ -53,7 +53,7 @@ import slib.utils.impl.SetUtils;
  *
  * The Log base used in this implementation is 10.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_edge_Leacock_Chodorow_1998 extends Sim_DAG_edge_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Pekar_Staab_2002.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Pekar_Staab_2002.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * 19th international conference on Computational linguistics. Association for
  * Computational Linguistics; 2002, 2:1–7.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_edge_Pekar_Staab_2002 extends Sim_DAG_edge_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Stojanovic_2001.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Stojanovic_2001.java
@@ -50,7 +50,7 @@ import slib.utils.impl.SetUtils;
  * Developing SEmantic PortALs. In Proceedings of the International Conference
  * on Knowl- edge Capture. , 2097/2001,.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_edge_Stojanovic_2001 extends Sim_DAG_edge_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Wu_Palmer_1994.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/Sim_pairwise_DAG_edge_Wu_Palmer_1994.java
@@ -50,7 +50,7 @@ import slib.utils.impl.SetUtils;
  * Wu Z, Palmer M: Verb semantics and lexical selection. In 32nd. Annual Meeting
  * of the Association for Computational Linguistics. 1994:133–138.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_edge_Wu_Palmer_1994 extends Sim_DAG_edge_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_Al_Mubaid_2006.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_Al_Mubaid_2006.java
@@ -44,7 +44,7 @@ import slib.sml.sm.core.utils.SMconf;
  * Conference of the IEEE Engineering in Medicine and Biology Society. IEEE
  * Engineering in Medicine and Biology Society. Conference 2006, 1:2713-7.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  *
  *

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_G_SESAME_2007.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_G_SESAME_2007.java
@@ -46,7 +46,7 @@ import slib.utils.impl.SetUtils;
 /**
  * TODO Check approximation using depth of concepts
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_edge_G_SESAME_2007 extends Sim_DAG_edge_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_Slimani_2006.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/experimental/Sim_pairwise_DAG_edge_Slimani_2006.java
@@ -49,7 +49,7 @@ import slib.utils.impl.SetUtils;
  * Edge Counting. In World academy of science, engineering and technology,.
  * 2006:34–38.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_edge_Slimani_2006 extends Sim_DAG_edge_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/utils/SimDagEdgeUtils.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/edge_based/utils/SimDagEdgeUtils.java
@@ -46,7 +46,7 @@ import slib.utils.impl.SetUtils;
 /**
  * Utility class for edge-based measures.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SimDagEdgeUtils {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/Sim_DAG_hybrid_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/Sim_DAG_hybrid_abstract.java
@@ -39,7 +39,7 @@ import slib.sml.sm.core.measures.graph.pairwise.dag.Sim_Pairwise_DAG;
  * Class used to represent a semantic similarity measure which is based on a
  * hybrid approach.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_DAG_hybrid_abstract extends Sim_Pairwise_DAG {
 }

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/experimental/Sim_pairwise_DAG_hybrid_Ranwez_2006.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/experimental/Sim_pairwise_DAG_hybrid_Ranwez_2006.java
@@ -49,7 +49,7 @@ import slib.utils.impl.SetUtils;
  *
  * distance converted as similarity using sim = - dist range ]-inf,0]
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  *
  */

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/experimental/Sim_pairwise_DAG_hybrid_Wang_2007.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/experimental/Sim_pairwise_DAG_hybrid_Wang_2007.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  * ﻿Wang JZ, Du Z, Payattakool R, Yu PS, Chen C-F: A new method to measure the semantic similarity of GO terms. 
  * Bioinformatics (Oxford, England) 2007, 23:1274-81.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_hybrid_Wang_2007 extends Sim_DAG_edge_abstract{

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/utils/SimDagHybridUtils.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/hybrid/utils/SimDagHybridUtils.java
@@ -48,7 +48,7 @@ import slib.graph.model.graph.weight.GWS;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SimDagHybridUtils {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_DAG_node_abstract.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_DAG_node_abstract.java
@@ -39,7 +39,7 @@ import slib.sml.sm.core.measures.graph.pairwise.dag.Sim_Pairwise_DAG;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class Sim_DAG_node_abstract extends Sim_Pairwise_DAG{
 	

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Constants.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Constants.java
@@ -35,7 +35,7 @@ package slib.sml.sm.core.measures.graph.pairwise.dag.node_based;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Constants {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Feature_Tversky_Contrast_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Feature_Tversky_Contrast_Model.java
@@ -48,7 +48,7 @@ import slib.utils.impl.SetUtils;
  * inclusive ancestors of a single common subsumer of the two concepts, i.e.
  * feature-like definition of the MICA/LCA ).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Feature_Tversky_Contrast_Model extends Sim_pairwise_DAG_node_IC_Tversky_Contrast_Model {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Feature_Tversky_Ratio_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Feature_Tversky_Ratio_Model.java
@@ -44,7 +44,7 @@ import slib.utils.impl.SetUtils;
  * A concept is represented as its sets of inclusive subsumers.
  * Note that the commonality is assessed based on the size of the intersection of the inclusive subsumers of the two compared concepts (which is, in some cases, not the same as the inclusive ancestors of a single common subsumer of the two concepts, i.e. feature-like definition of the MICA/LCA ).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Feature_Tversky_Ratio_Model extends Sim_pairwise_DAG_node_IC_Tversky_Ratio_Model {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_GL.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_GL.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Exception;
  * proposed by Blanchard E, Harzallah M, Kuntz P: A generic framework for
  * comparing semantic similarities on a subsumption hierarchy. 2008:20–24.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_GL extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Prop_Tversky_Contrast_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Prop_Tversky_Contrast_Model.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
 /**
  * IC formulation of Tversky Ratio Model
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_IC_Prop_Tversky_Contrast_Model extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Prop_Tversky_Ratio_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Prop_Tversky_Ratio_Model.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
 /**
  * IC formulation of Tversky Ratio Model
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_IC_Prop_Tversky_Ratio_Model extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Tversky_Contrast_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Tversky_Contrast_Model.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * IC formulation of Tversky Ratio Model
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_IC_Tversky_Contrast_Model extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Tversky_Ratio_Model.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_IC_Tversky_Ratio_Model.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * IC formulation of Tversky Ratio Model
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_IC_Tversky_Ratio_Model extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jaccard_3W_IC.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jaccard_3W_IC.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  *
  * sim(a,b) = (3 * ic_mica) / (ic_a + ic_b + 2 * ic_mica)
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Jaccard_3W_IC extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jaccard_IC.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jaccard_IC.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  *
  * sim(a,b) = ic_mica / (ic_a + ic_b - ic_mica)
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Jaccard_IC extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jiang_Conrath_1997.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jiang_Conrath_1997.java
@@ -43,7 +43,7 @@ import slib.utils.ex.SLIB_Exception;
  * Lexical Taxonomy. In International Conference Research on Computational
  * Linguistics (ROCLING X). 1997, cmp-lg/970:15.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Jiang_Conrath_1997 extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jiang_Conrath_1997_Norm.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Jiang_Conrath_1997_Norm.java
@@ -57,7 +57,7 @@ import slib.utils.ex.SLIB_Exception;
  * The normalization makes sens only if IC of compared concepts are normalized
  * [0;1]
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Jiang_Conrath_1997_Norm extends  Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Lin_1998.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Lin_1998.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  * defined in a taxonomy.
  *
  * <p>
- * SYMMETRIC = YES <br/>
+ * SYMMETRIC = YES <br>
  * VALUE : [0,1]
  * </p>
  *
@@ -60,14 +60,14 @@ import slib.utils.ex.SLIB_Exception;
  * relies on a ratio between the IC of the Most Specific Common Ancestor of the
  * compared concepts and the sum of their IC. The MICA is therefore the common
  * ancestor of the compared concepts which maximizes the selected IC function.
- * If multiple MICAs are found only one will be considered. <br/> <br/>
+ * If multiple MICAs are found only one will be considered. <br> <br>
  *
- * The measure is therefore defined by: <br/><br/>
+ * The measure is therefore defined by: <br><br>
  *
  * <code>
  * sim(u,v) = 2 x IC(MICA(u,v)) / (IC(u) + IC(v))
  * </code>
- * <br/><br/>
+ * <br><br>
  * Note that originally, the formulation proposed by Lin considered <code>IC(u) =
  * log(p(u))</code> which is equivalent to considering the IC formulation
  * proposed by Resnik <code>IC(u) = -log(p(u))</code>. However, in this
@@ -75,7 +75,7 @@ import slib.utils.ex.SLIB_Exception;
  * from the leaves to the root(s) of the taxonomy.
  * </p>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Lin_1998 extends  Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Resnik_1995.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Resnik_1995.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  * Artificial Intelligence IJCAI. 1995, 1:448-453.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Resnik_1995 extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Schlicker_2006_SimRel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Schlicker_2006_SimRel.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
  * Schlicker, Andreas, et al. "A new measure for functional similarity of gene
  * products based on Gene Ontology." BMC bioinformatics 7.1 (2006): 302.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Schlicker_2006_SimRel extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Sim_IC_2010.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/Sim_pairwise_DAG_node_Sim_IC_2010.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
  * improve the GO-based similarity measure between proteins. Bo Li, James Z.
  * Wang, F. Alex Feltus, Jizhong Zhou, Feng Luo
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Sim_IC_2010 extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_GL_GraSM.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_GL_GraSM.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_GL_GraSM extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Harispe_2013.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Harispe_2013.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 import slib.utils.ex.SLIB_Exception;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Harispe_2013 extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Lin_1998_GraSM.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Lin_1998_GraSM.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Exception;
  * Lin D: An Information-Theoretic Definition of Similarity. In 15th
  * International Conference of Machine Learning. Madison,WI: 1998:296-304.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Lin_1998_GraSM extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Mazandu_2012.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Mazandu_2012.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Exception;
  * vol. 2012, Article ID 975783, 17 pages, 2012. doi:10.1155/2012/975783
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Mazandu_2012 extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_Ancestors.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_Ancestors.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Ex_Warning;
  * Artificial Intelligence IJCAI. 1995, 1:448-453.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Resnik_1995_Ancestors extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_Descendants.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_Descendants.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Ex_Warning;
  * Artificial Intelligence IJCAI. 1995, 1:448-453.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Resnik_1995_Descendants extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_GraSM.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Resnik_1995_GraSM.java
@@ -47,7 +47,7 @@ import slib.utils.ex.SLIB_Exception;
  * Artificial Intelligence IJCAI. 1995, 1:448-453.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_pairwise_DAG_node_Resnik_1995_GraSM extends Sim_DAG_node_abstract {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_3WJaccard_SimRel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_3WJaccard_SimRel.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Schlicker_3WJaccard_SimRel extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_GL_SimRel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_GL_SimRel.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Schlicker_GL_SimRel extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_Jaccard_SimRel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_Jaccard_SimRel.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Schlicker_Jaccard_SimRel extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_Tversky_SimRel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/graph/pairwise/dag/node_based/experimental/Sim_pairwise_DAG_node_Schlicker_Tversky_SimRel.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_DAG_node_Schlicker_Tversky_SimRel extends Sim_DAG_node_abstract {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/direct/Sim_groupwise_Random.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/direct/Sim_groupwise_Random.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  * Random measure (used for test)
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_Random extends Sim_Groupwise_Direct {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/direct/vector/VectorSpaceModel.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/direct/vector/VectorSpaceModel.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class VectorSpaceModel extends Sim_Groupwise_Direct {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Average.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Average.java
@@ -45,7 +45,7 @@ import slib.utils.impl.MatrixDouble;
 /**
  * Classic Average Measure Assumes score symmetry
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_Average extends Sim_Groupwise_Indirect {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_BestMatchAverage.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_BestMatchAverage.java
@@ -49,7 +49,7 @@ import slib.utils.impl.MatrixDouble;
  * 
  * Also called funSim in the literature.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_BestMatchAverage extends Sim_Groupwise_Indirect {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_BestMatchMax.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_BestMatchMax.java
@@ -49,7 +49,7 @@ import slib.utils.impl.MatrixDouble;
  * Bioinformatics 2006, 7:302.
  *
  * Also called funSim in the literature.
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_BestMatchMax extends Sim_Groupwise_Indirect {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Lord_2003.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Lord_2003.java
@@ -55,7 +55,7 @@ import slib.utils.impl.MatrixDouble;
  * 
  * Corresponds to the Average Strategy
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_Lord_2003 extends Sim_Groupwise_Indirect {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Max.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Max.java
@@ -44,7 +44,7 @@ import slib.utils.impl.MatrixDouble;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_Max extends Sim_Groupwise_Indirect {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Min.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/Sim_groupwise_Min.java
@@ -44,7 +44,7 @@ import slib.utils.impl.MatrixDouble;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_groupwise_Min extends Sim_Groupwise_Indirect {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/experimental/Sim_groupwise_AVERAGE_NORMALIZED_GOSIM.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/experimental/Sim_groupwise_AVERAGE_NORMALIZED_GOSIM.java
@@ -48,7 +48,7 @@ import slib.utils.impl.MatrixDouble;
  * products. BMC bioinformatics 2007, 8:166. Implementation as defined in
  * equation 7 page 3/8
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_AVERAGE_NORMALIZED_GOSIM extends Sim_Groupwise_Indirect {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/experimental/Sim_groupwise_MAX_NORMALIZED_GOSIM.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/groupwise/indirect/experimental/Sim_groupwise_MAX_NORMALIZED_GOSIM.java
@@ -49,7 +49,7 @@ import slib.utils.impl.MatrixDouble;
  * products. BMC bioinformatics 2007, 8:166. Implementation as defined in
  * equation 7 page 3/8
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Sim_groupwise_MAX_NORMALIZED_GOSIM extends Sim_Groupwise_Indirect {

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/others/pairwise/Sim_pairwise_Random.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/others/pairwise/Sim_pairwise_Random.java
@@ -44,7 +44,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Random measure for tests
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sim_pairwise_Random extends Sim_Pairwise {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/string/LevenshteinDistance.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/string/LevenshteinDistance.java
@@ -41,10 +41,10 @@ package slib.sml.sm.core.measures.string;
  * "Binary codes capable of correcting deletions, insertions, and reversals". 
  * Soviet Physics Doklady 10: 707–10.
  * 
- * Normalized = distance(a,b) / (b.length() > a.length() ? b.length() : a.length());
+ * {@literal Normalized = distance(a,b) / (b.length() > a.length() ? b.length() : a.length());}
  * i.e. distance divided by the length of the longer String
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class LevenshteinDistance {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/string/LevenshteinSimilarity.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/string/LevenshteinSimilarity.java
@@ -39,7 +39,7 @@ package slib.sml.sm.core.measures.string;
  *  not normalized =  length(longest string) - distance
  * 
  * @see LevenshteinDistance
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class LevenshteinSimilarity extends LevenshteinDistance{
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/measures/vector/CosineSimilarity.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/measures/vector/CosineSimilarity.java
@@ -36,7 +36,7 @@ package slib.sml.sm.core.measures.vector;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class CosineSimilarity {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/IC.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/IC.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Interface defining the methods representing an IC computer.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface IC {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_annot_resnik_1995.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_annot_resnik_1995.java
@@ -68,7 +68,7 @@ import slib.utils.ex.SLIB_Exception;
  * is a concept which does not subsumes any concept.
  * </p>
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class IC_annot_resnik_1995 extends LogBasedMetric implements ICcorpus {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_annot_resnik_1995_Normalized.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_annot_resnik_1995_Normalized.java
@@ -61,7 +61,7 @@ import slib.utils.ex.SLIB_Exception;
  * IC_norm(c) = IC(c)/ log(nbAnnot) Here nbAnnot = |V|
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class IC_annot_resnik_1995_Normalized extends LogBasedMetric implements ICcorpus {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_probOccurence_propagatted.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/IC_probOccurence_propagatted.java
@@ -43,7 +43,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class IC_probOccurence_propagatted extends LogBasedMetric implements ICcorpus {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/ICcorpus.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/annot/ICcorpus.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface ICcorpus {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_ancestors_norm.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_ancestors_norm.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  * Basic definition of an estimator of specificity based on the number of ancestors.
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ICi_ancestors_norm implements ICtopo{
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_max_linear.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_max_linear.java
@@ -42,7 +42,7 @@ import slib.sml.sm.core.metrics.utils.LogBasedMetric;
 import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_depth_max_linear extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_max_nonlinear.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_max_nonlinear.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_depth_max_nonlinear extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_min_nonlinear.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_depth_min_nonlinear.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_depth_min_nonlinear extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_harispe_2012.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_harispe_2012.java
@@ -67,7 +67,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * 24:297-303.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ICi_harispe_2012 extends LogBasedMetric implements ICtopo {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_probOccurence.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_probOccurence.java
@@ -54,7 +54,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * tool for protein semantic similarity. 2007.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_probOccurence implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_probOccurence_propagatted.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_probOccurence_propagatted.java
@@ -54,7 +54,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * tool for protein semantic similarity. 2007.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_probOccurence_propagatted implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_resnik_1995.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_resnik_1995.java
@@ -58,7 +58,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * tool for protein semantic similarity. 2007.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_resnik_1995 extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_resnik_unpropagatted_1995.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_resnik_unpropagatted_1995.java
@@ -58,7 +58,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * tool for protein semantic similarity. 2007.
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_resnik_unpropagatted_1995 extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_sanchez_2011.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_sanchez_2011.java
@@ -56,7 +56,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * IC inner expression range : ]0,1] IC value : [0,...[
  *
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ICi_sanchez_2011 extends LogBasedMetric implements ICtopo {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_seco_2004.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_seco_2004.java
@@ -50,7 +50,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  *
  * IC range : [0,1]
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ICi_seco_2004 extends LogBasedMetric implements ICtopo {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_zhou_2008.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICi_zhou_2008.java
@@ -53,7 +53,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  *
  * IC range : [0,1]
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ICi_zhou_2008 extends LogBasedMetric implements ICtopo {

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICtopo.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/topo/ICtopo.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Class representing Topological Information Content
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface ICtopo {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IC_Conf_Corpus.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IC_Conf_Corpus.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  *
  * Class used to represent configurations dedicated to Corpus-based IC.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IC_Conf_Corpus extends ICconf {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IC_Conf_Topo.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IC_Conf_Topo.java
@@ -37,7 +37,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IC_Conf_Topo extends ICconf {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/ICconf.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/ICconf.java
@@ -39,7 +39,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public abstract class ICconf extends Conf {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IcUtils.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/IcUtils.java
@@ -45,7 +45,7 @@ import slib.utils.impl.SetUtils;
  *
  * Class used to defined static methods utility.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class IcUtils {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/ProbOccurence.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/ic/utils/ProbOccurence.java
@@ -43,7 +43,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ProbOccurence implements ICtopo {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/utils/LogBasedMetric.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/utils/LogBasedMetric.java
@@ -39,7 +39,7 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class LogBasedMetric implements LogBasedMetricInterface{
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/utils/LogBasedMetricInterface.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/utils/LogBasedMetricInterface.java
@@ -39,7 +39,7 @@ import slib.utils.i.Conf;
 
 /**
  * Interface implemented by classes depending on a log base configuration.
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface LogBasedMetricInterface {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/vector/VectorWeight_Chabalier_2007.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/vector/VectorWeight_Chabalier_2007.java
@@ -48,7 +48,7 @@ import slib.sml.sm.core.engine.SM_Engine;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class VectorWeight_Chabalier_2007 {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/metrics/vector/VectorWeight_Chabalier_Propaggated.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/metrics/vector/VectorWeight_Chabalier_Propaggated.java
@@ -48,7 +48,7 @@ import slib.sml.sm.core.engine.SM_Engine;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class VectorWeight_Chabalier_Propaggated {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/LCAFinder.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/LCAFinder.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface LCAFinder {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/LCAFinderImpl.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/LCAFinderImpl.java
@@ -59,7 +59,7 @@ import slib.utils.impl.SetUtils;
  * Dummy implementation of the LCAFinder interface (high algorithmic
  * complexity).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class LCAFinderImpl implements LCAFinder {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/MathSML.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/MathSML.java
@@ -36,7 +36,7 @@ package slib.sml.sm.core.utils;
 /**
  * Class used to define some utility method for mathematical treatments.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MathSML {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/OperatorConf.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/OperatorConf.java
@@ -40,7 +40,7 @@ import slib.utils.i.Conf;
  *
  * Configuration of an Operator
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OperatorConf extends Conf {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/SMConstants.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/SMConstants.java
@@ -125,7 +125,7 @@ import slib.sml.sm.core.metrics.ic.topo.ICi_zhou_2008;
  *
  * TODO requires to be split in a smart way.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public final class SMConstants {

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/SMParams.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/SMParams.java
@@ -35,7 +35,7 @@ package slib.sml.sm.core.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum SMParams {
     

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/SMconf.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/SMconf.java
@@ -40,7 +40,7 @@ import slib.utils.i.Conf;
 /**
  * Representation of the configuration of a semantic measure.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMconf extends Conf {
 

--- a/slib-sml/src/main/java/slib/sml/sm/core/utils/SMutils.java
+++ b/slib-sml/src/main/java/slib/sml/sm/core/utils/SMutils.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Class used to define utility methods.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMutils {
 

--- a/slib-sml/src/main/java/slib/sml/smutils/ResultsMerger.java
+++ b/slib-sml/src/main/java/slib/sml/smutils/ResultsMerger.java
@@ -56,7 +56,7 @@ import slib.utils.impl.BigFileReader;
  * Used to results merge files.
  * Comment start by ! and the process consider first line as header (except those starting by !)
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class ResultsMerger {

--- a/slib-sml/src/main/java/slib/sml/smutils/SQLiteUtils.java
+++ b/slib-sml/src/main/java/slib/sml/smutils/SQLiteUtils.java
@@ -79,7 +79,7 @@ import slib.utils.ex.SLIB_Exception;
  * databases containing tables with more than 500 columns. If such big table are
  * processed a SQL_Exception will be throw.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class SQLiteUtils {

--- a/slib-sml/src/test/java/test/TestGraphEngine.java
+++ b/slib-sml/src/test/java/test/TestGraphEngine.java
@@ -61,7 +61,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestGraphEngine {
 

--- a/slib-sml/src/test/java/test/TestGroupwiseIndirectMeasures.java
+++ b/slib-sml/src/test/java/test/TestGroupwiseIndirectMeasures.java
@@ -52,7 +52,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 import slib.utils.impl.MatrixDouble;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestGroupwiseIndirectMeasures {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/CmdHandler.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/CmdHandler.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Abstract command handler
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public abstract class CmdHandler {

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/FilterBuilderGeneric.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/FilterBuilderGeneric.java
@@ -47,7 +47,7 @@ import slib.utils.impl.Util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FilterBuilderGeneric {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/GenericConfBuilder.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/GenericConfBuilder.java
@@ -46,14 +46,14 @@ import slib.utils.i.Conf;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GenericConfBuilder {
 
     static final Pattern patternRgx = Pattern.compile("\\{([^\\{^\\}]*)\\}");
 
     /**
-     * Apply loaded patterns to a string (see {@link GlobalConfPattern} ) <br/>
+     * Apply loaded patterns to a string (see {@link GlobalConfPattern} ) <br>
      * if a pattern {@link XmlTags#VARIABLE_TAG} HOME is set to /tmp the method
      * will return /tmp/test/graph if {HOME}/test/graph is set as input
      *

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/GlobalConfPattern.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/GlobalConfPattern.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class GlobalConfPattern {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ModuleConf.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ModuleConf.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Interface defining the methods a module configuration
  * must implements.
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public interface ModuleConf {

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ModuleCst.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ModuleCst.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * Abstract class defining the constant expected to be specified for each module
  * configuration.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public abstract class ModuleCst {

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ToolCmdHandlerCst.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/ToolCmdHandlerCst.java
@@ -39,7 +39,7 @@ import org.apache.commons.cli.Option;
 /**
  * Abstract class defining the default constants of a tool command handler.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public abstract class ToolCmdHandlerCst {

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XMLConfLoaderGeneric.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XMLConfLoaderGeneric.java
@@ -74,7 +74,7 @@ import slib.utils.threads.ThreadManager;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class XMLConfLoaderGeneric {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XMLConstUtils.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XMLConstUtils.java
@@ -35,7 +35,7 @@ package slib.tools.module;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class XMLConstUtils {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XML_ModuleConfLoader.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XML_ModuleConfLoader.java
@@ -38,7 +38,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class XML_ModuleConfLoader {
 

--- a/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XmlTags.java
+++ b/slib-tools/slib-tools-module/src/main/java/slib/tools/module/XmlTags.java
@@ -36,7 +36,7 @@ package slib.tools.module;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class XmlTags {
 	

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/OntoFocusCmdHandler.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/OntoFocusCmdHandler.java
@@ -64,7 +64,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public final class OntoFocusCmdHandler extends CmdHandler {
 

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/debug/App.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/debug/App.java
@@ -37,7 +37,7 @@ import slib.tools.ontofocus.cli.OntoFocusCmdHandler;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class App {
 

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/utils/OntoFocusCmdHandlerCst.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/cli/utils/OntoFocusCmdHandlerCst.java
@@ -43,7 +43,7 @@ import slib.tools.module.ToolCmdHandlerCst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OntoFocusCmdHandlerCst extends ToolCmdHandlerCst {
 

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/OntoFocus.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/OntoFocus.java
@@ -61,7 +61,7 @@ import slib.utils.impl.QueryFileIterator;
 import slib.utils.impl.SetUtils;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OntoFocus {
 

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/utils/OntoFocusCst.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/utils/OntoFocusCst.java
@@ -38,7 +38,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OntoFocusCst extends ModuleCst {
 

--- a/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/utils/QueryEntryURI.java
+++ b/slib-tools/slib-tools-ontofocus/src/main/java/slib/tools/ontofocus/core/utils/QueryEntryURI.java
@@ -40,7 +40,7 @@ import org.openrdf.model.URI;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public final class QueryEntryURI implements Map.Entry<String, Set<URI> > {
 	

--- a/slib-tools/slib-tools-ontofocus/src/test/java/slib/tools/ontofocus/TestOntoFocusReduction.java
+++ b/slib-tools/slib-tools-ontofocus/src/test/java/slib/tools/ontofocus/TestOntoFocusReduction.java
@@ -23,7 +23,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class TestOntoFocusReduction {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlModuleCLI.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlModuleCLI.java
@@ -37,7 +37,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface SmlModuleCLI {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCli.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCli.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Exception;
 /**
  * Semantic Measures Library Toolkit Command Line Interface
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class SmlToolKitCli extends CmdHandler {

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCliCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCliCst.java
@@ -41,7 +41,7 @@ import slib.tools.module.ToolCmdHandlerCst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmlToolKitCliCst extends ToolCmdHandlerCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/SmlToolKitCst.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Constant of the Semantic Framework Module
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class SmlToolKitCst extends ModuleCst {

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/conf/xml/loader/Sm_XMLConfLoader.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/conf/xml/loader/Sm_XMLConfLoader.java
@@ -66,7 +66,7 @@ import slib.utils.impl.Util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sm_XMLConfLoader extends XML_ModuleConfLoader {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/conf/xml/utils/Sm_XML_Cst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/conf/xml/utils/Sm_XML_Cst.java
@@ -35,7 +35,7 @@ package slib.tools.smltoolkit.sm.cli.conf.xml.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Sm_XML_Cst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/SmCli.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/SmCli.java
@@ -81,7 +81,7 @@ import slib.utils.threads.ThreadManager;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmCli implements SmlModuleCLI {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/cmd/SmCmdHandler.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/cmd/SmCmdHandler.java
@@ -48,7 +48,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmCmdHandler extends CmdHandler {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/cmd/SmCmdHandlerCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/cmd/SmCmdHandlerCst.java
@@ -43,7 +43,7 @@ import slib.tools.smltoolkit.SmlToolKitCliCst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmCmdHandlerCst extends ToolCmdHandlerCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/ActionParamsUtils.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/ActionParamsUtils.java
@@ -37,7 +37,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ActionParamsUtils {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/ActionsParams.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/ActionsParams.java
@@ -35,7 +35,7 @@ package slib.tools.smltoolkit.sm.cli.core.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public enum ActionsParams {
     

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/FileWriterUtil.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/FileWriterUtil.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 /**
  * Dummy class used to write a String into a file
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FileWriterUtil {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/QueryConceptsIterator.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/QueryConceptsIterator.java
@@ -46,7 +46,7 @@ import slib.utils.impl.QueryIterator;
  * according to the set of concepts (CLASS) composing the graph. Considered as
  * Symmetric
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class QueryConceptsIterator implements QueryIterator {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SML_SM_module_XML_block_conf.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SML_SM_module_XML_block_conf.java
@@ -35,7 +35,7 @@ package slib.tools.smltoolkit.sm.cli.core.utils;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SML_SM_module_XML_block_conf {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SMQueryParam.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SMQueryParam.java
@@ -34,7 +34,7 @@
 package slib.tools.smltoolkit.sm.cli.core.utils;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMQueryParam {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SMutils.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SMutils.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SMutils {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SmToolkitCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/SmToolkitCst.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmToolkitCst extends ModuleCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/XMLConfUtils.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/XMLConfUtils.java
@@ -43,7 +43,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class XMLConfUtils {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/ConceptToConcept_Thread.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/ConceptToConcept_Thread.java
@@ -52,7 +52,7 @@ import slib.utils.threads.PoolWorker;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ConceptToConcept_Thread implements Callable<ThreadResultsQueryLoader> {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/EntityToEntity_Thread.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/EntityToEntity_Thread.java
@@ -58,7 +58,7 @@ import slib.utils.threads.PoolWorker;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class EntityToEntity_Thread implements Callable<ThreadResultsQueryLoader> {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/ThreadResultsQueryLoader.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/core/utils/calc/ThreadResultsQueryLoader.java
@@ -35,7 +35,7 @@ package slib.tools.smltoolkit.sm.cli.core.utils.calc;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ThreadResultsQueryLoader {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfileGOCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfileGOCst.java
@@ -44,7 +44,7 @@ import slib.tools.smltoolkit.SmlToolKitCliCst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfileGOCst extends ToolCmdHandlerCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfileGOHandler.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfileGOHandler.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfileGOHandler extends CmdHandler {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfile_GO.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmProfile_GO.java
@@ -47,7 +47,7 @@ import slib.utils.impl.Util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfile_GO implements SmlModuleCLI {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmToolkitGOCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/go/SmToolkitGOCst.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmToolkitGOCst extends ModuleCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfileMeSHCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfileMeSHCst.java
@@ -42,7 +42,7 @@ import slib.tools.smltoolkit.SmlToolKitCliCst;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfileMeSHCst extends ToolCmdHandlerCst {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfileMeSHHandler.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfileMeSHHandler.java
@@ -46,7 +46,7 @@ import slib.utils.ex.SLIB_Exception;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfileMeSHHandler extends CmdHandler {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfile_MeSH.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmProfile_MeSH.java
@@ -44,7 +44,7 @@ import slib.utils.impl.Util;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmProfile_MeSH implements SmlModuleCLI {
 

--- a/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmToolkitMeSHCst.java
+++ b/slib-tools/slib-tools-sml-toolkit/src/main/java/slib/tools/smltoolkit/sm/cli/profile/mesh/SmToolkitMeSHCst.java
@@ -39,7 +39,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SmToolkitMeSHCst extends ModuleCst {
 

--- a/slib-utils/src/main/java/slib/utils/FileUtils.java
+++ b/slib-utils/src/main/java/slib/utils/FileUtils.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class FileUtils {
 

--- a/slib-utils/src/main/java/slib/utils/ex/SLIB_Ex_Critic.java
+++ b/slib-utils/src/main/java/slib/utils/ex/SLIB_Ex_Critic.java
@@ -35,7 +35,7 @@ package slib.utils.ex;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SLIB_Ex_Critic extends SLIB_Exception {
 

--- a/slib-utils/src/main/java/slib/utils/ex/SLIB_Ex_Warning.java
+++ b/slib-utils/src/main/java/slib/utils/ex/SLIB_Ex_Warning.java
@@ -35,7 +35,7 @@ package slib.utils.ex;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SLIB_Ex_Warning extends SLIB_Exception {
 

--- a/slib-utils/src/main/java/slib/utils/ex/SLIB_Exception.java
+++ b/slib-utils/src/main/java/slib/utils/ex/SLIB_Exception.java
@@ -35,7 +35,7 @@ package slib.utils.ex;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SLIB_Exception extends Exception{
 

--- a/slib-utils/src/main/java/slib/utils/i/CheckableValidity.java
+++ b/slib-utils/src/main/java/slib/utils/i/CheckableValidity.java
@@ -35,7 +35,7 @@ package slib.utils.i;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface CheckableValidity {
 

--- a/slib-utils/src/main/java/slib/utils/i/Conf.java
+++ b/slib-utils/src/main/java/slib/utils/i/Conf.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * flag of the parameter and the value is an {@link Object} corresponding to the
  * value associated to the related key.
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class Conf {

--- a/slib-utils/src/main/java/slib/utils/i/Parametrable.java
+++ b/slib-utils/src/main/java/slib/utils/i/Parametrable.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface Parametrable {
 

--- a/slib-utils/src/main/java/slib/utils/impl/BigFileReader.java
+++ b/slib-utils/src/main/java/slib/utils/impl/BigFileReader.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class BigFileReader {
 

--- a/slib-utils/src/main/java/slib/utils/impl/IO_RuntimeException.java
+++ b/slib-utils/src/main/java/slib/utils/impl/IO_RuntimeException.java
@@ -36,7 +36,7 @@ package slib.utils.impl;
 /**
  * TODO modify or remove
  * 
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class IO_RuntimeException extends RuntimeException {

--- a/slib-utils/src/main/java/slib/utils/impl/MatrixDouble.java
+++ b/slib-utils/src/main/java/slib/utils/impl/MatrixDouble.java
@@ -45,7 +45,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
  * @param <C> Object to index Columns
  * @param <R> Object to index Rows
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class MatrixDouble<C, R> {
 

--- a/slib-utils/src/main/java/slib/utils/impl/MatrixDynamic.java
+++ b/slib-utils/src/main/java/slib/utils/impl/MatrixDynamic.java
@@ -42,7 +42,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  * @param <N>
  */
 public class MatrixDynamic<N extends Number> {

--- a/slib-utils/src/main/java/slib/utils/impl/OBOconstants.java
+++ b/slib-utils/src/main/java/slib/utils/impl/OBOconstants.java
@@ -36,7 +36,7 @@ package slib.utils.impl;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OBOconstants {
 	

--- a/slib-utils/src/main/java/slib/utils/impl/OProperty.java
+++ b/slib-utils/src/main/java/slib/utils/impl/OProperty.java
@@ -40,7 +40,7 @@ import java.util.Set;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class OProperty {
 

--- a/slib-utils/src/main/java/slib/utils/impl/ParametrableImpl.java
+++ b/slib-utils/src/main/java/slib/utils/impl/ParametrableImpl.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import slib.utils.i.Parametrable;
 
 /**
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ParametrableImpl implements Parametrable {
 

--- a/slib-utils/src/main/java/slib/utils/impl/QueryEntry.java
+++ b/slib-utils/src/main/java/slib/utils/impl/QueryEntry.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public final class QueryEntry implements Map.Entry<String, String> {
 

--- a/slib-utils/src/main/java/slib/utils/impl/QueryFileIterator.java
+++ b/slib-utils/src/main/java/slib/utils/impl/QueryFileIterator.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * Query Iterator implementing the {@link QueryIterator} interface used to
  * iterate through the queries defined in a tabular delimited file i.e. e1\te2
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  *
  */
 public class QueryFileIterator implements QueryIterator {

--- a/slib-utils/src/main/java/slib/utils/impl/QueryIterator.java
+++ b/slib-utils/src/main/java/slib/utils/impl/QueryIterator.java
@@ -41,7 +41,7 @@ import java.util.List;
  * The Query iterator thus enables to iterate through the full set of queries
  * contained in a particular repository (in file, in memory collection).
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public interface QueryIterator {
 

--- a/slib-utils/src/main/java/slib/utils/impl/SetUtils.java
+++ b/slib-utils/src/main/java/slib/utils/impl/SetUtils.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class SetUtils {
 
@@ -93,12 +93,12 @@ public class SetUtils {
     }
 
     /**
-     * Build a Set<X> containing the given object of type X. If the object is
-     * null, null is returned
+     * Build a {@code Set<X>} containing the given object of type X. If the
+     * object is null, null is returned
      *
      * @param <X>
      * @param o
-     * @return a Set<X> containing the given object of type X or null
+     * @return a {@code Set<X>} containing the given object of type X or null
      */
     public static <X> Set<X> buildSet(X o) {
         if (o == null) {

--- a/slib-utils/src/main/java/slib/utils/impl/Timer.java
+++ b/slib-utils/src/main/java/slib/utils/impl/Timer.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Timer {
 

--- a/slib-utils/src/main/java/slib/utils/impl/Util.java
+++ b/slib-utils/src/main/java/slib/utils/impl/Util.java
@@ -37,7 +37,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class Util {
 

--- a/slib-utils/src/main/java/slib/utils/threads/PoolLocker.java
+++ b/slib-utils/src/main/java/slib/utils/threads/PoolLocker.java
@@ -35,7 +35,7 @@ package slib.utils.threads;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class PoolLocker {
 

--- a/slib-utils/src/main/java/slib/utils/threads/PoolWorker.java
+++ b/slib-utils/src/main/java/slib/utils/threads/PoolWorker.java
@@ -41,7 +41,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class PoolWorker extends PoolLocker {
 

--- a/slib-utils/src/main/java/slib/utils/threads/ThreadManager.java
+++ b/slib-utils/src/main/java/slib/utils/threads/ThreadManager.java
@@ -40,7 +40,7 @@ import slib.utils.ex.SLIB_Ex_Critic;
 
 /**
  *
- * @author Sébastien Harispe <sebastien.harispe@gmail.com>
+ * @author Sébastien Harispe (sebastien.harispe@gmail.com)
  */
 public class ThreadManager extends PoolLocker {
 


### PR DESCRIPTION
JDK 8 and later have strict syntax requirements for Javadoc. This change allows Maven to build the package target to completion on the new JDKs.

See:
https://stackoverflow.com/questions/22528767/jdk8-and-javadoc-has-become-very-strict
https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html