### PR TITLE
Use maven-assembly-plugin goal "single" instead of "attached"

### DIFF
--- a/slib-dsm/pom.xml
+++ b/slib-dsm/pom.xml
@@ -104,7 +104,7 @@
                         <id>make-assembly-egs</id>
                         <phase>package</phase><!-- append to the packaging phase. -->
                         <goals>
-                            <goal>attached</goal><!-- goals == mojos -->
+                            <goal>single</goal><!-- goals == mojos -->
                         </goals>
                     </execution>
                 </executions>

--- a/slib-tools/slib-tools-ontofocus/pom.xml
+++ b/slib-tools/slib-tools-ontofocus/pom.xml
@@ -126,7 +126,7 @@
                         <id>make-assembly-ontofocus</id><!-- this is used for inheritance merges -->
                         <phase>package</phase><!-- append to the packaging phase. -->
                         <goals>
-                            <goal>attached</goal><!-- goals == mojos -->
+                            <goal>single</goal><!-- goals == mojos -->
                         </goals>
                     </execution>
                 </executions>

--- a/slib-tools/slib-tools-sml-toolkit/pom.xml
+++ b/slib-tools/slib-tools-sml-toolkit/pom.xml
@@ -123,7 +123,7 @@
                         <id>make-assembly-sml-toolkit</id><!-- this is used for inheritance merges -->
                         <phase>package</phase><!-- append to the packaging phase. -->
                         <goals>
-                            <goal>attached</goal><!-- goals == mojos -->
+                            <goal>single</goal><!-- goals == mojos -->
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Without this patch, `mvn package` fails with the error "Could not find goal 'attached' in plugin org.apache.maven.plugins:maven-assembly-plugin:3.0.0 among available goals help, single".

According to <http://maven.apache.org/plugins-archives/maven-assembly-plugin-2.5.5/attached-mojo.html>, the goal "attached" was deprecated in favor of the goal "single".